### PR TITLE
Fix duplicate NextResponse import in ping API route

### DIFF
--- a/app/api/ping/route.ts
+++ b/app/api/ping/route.ts
@@ -1,8 +1,6 @@
-import { NextResponse as NextResp } from "next/server";
-
-import { NextResponse as NextResp } from "next/server";
+import { NextResponse } from "next/server";
 
 export async function GET() {
   const message = process.env.PING_MESSAGE ?? "ping";
-  return NextResp.json({ message });
+  return NextResponse.json({ message });
 }


### PR DESCRIPTION
## Purpose

The user was experiencing a 500 error when testing the `/api/ping` endpoint. The error was caused by duplicate and inconsistent imports of NextResponse in the ping route file, which was preventing the API from functioning properly.

## Code changes

- Removed duplicate `NextResponse` import statements
- Standardized the import to use `NextResponse` instead of the aliased `NextResp`
- Updated the return statement to use the consistent `NextResponse` naming
- Cleaned up the import section to have a single, proper import declarationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3de5e6845cce4110925b75ca516c955a/nova-field)

👀 [Preview Link](https://3de5e6845cce4110925b75ca516c955a-nova-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3de5e6845cce4110925b75ca516c955a</projectId>-->
<!--<branchName>nova-field</branchName>-->